### PR TITLE
Implement getting past player incidents

### DIFF
--- a/src/main/java/me/ebonjaeger/novuspunishment/Message.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/Message.java
@@ -34,8 +34,10 @@ public enum Message {
     PLAYER_UNBANNED(Prefix.INFO, "{0} has been unbanned from the server!"),
     PLAYER_NOT_BANNED(Prefix.ERROR, "{0} is not currently banned!"),
 
+    ERROR_GETTING_COUNT(Prefix.ERROR, "There was an error getting the incident count!"),
     UNKNOWN_PLAYER(Prefix.ERROR, "Player '{0}' could not be found!"),
-    INVALID_DURATION(Prefix.ERROR, "Invalid time duration format: " + ChatColor.WHITE);
+    INVALID_DURATION(Prefix.ERROR, "Invalid time duration format: " + ChatColor.WHITE),
+    INVALID_PAGE(Prefix.ERROR, "Page does not exist!");
 
     private Prefix prefix;
     private String message;

--- a/src/main/java/me/ebonjaeger/novuspunishment/NovusPunishment.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/NovusPunishment.java
@@ -70,6 +70,7 @@ public class NovusPunishment extends JavaPlugin {
         commandManager.registerCommand(injector.getSingleton(TempbanCommand.class));
         commandManager.registerCommand(injector.getSingleton(BanCommand.class));
         commandManager.registerCommand(injector.getSingleton(UnbanCommand.class));
+        commandManager.registerCommand(injector.getSingleton(GetReportCommand.class));
     }
 
     public boolean isShuttingDown() {

--- a/src/main/java/me/ebonjaeger/novuspunishment/StateManager.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/StateManager.java
@@ -27,7 +27,7 @@ public class StateManager {
      * @param uniqueID    The player's unique ID
      * @param playerState The player's current state
      */
-    public void addPlayerState(UUID uniqueID, PlayerState playerState) {
+    public synchronized void addPlayerState(UUID uniqueID, PlayerState playerState) {
         playerStates.put(uniqueID, playerState);
     }
 
@@ -39,7 +39,7 @@ public class StateManager {
      * @param uniqueID The player's unique ID
      * @return The player's state, or null
      */
-    public PlayerState getPlayerState(UUID uniqueID) {
+    public synchronized PlayerState getPlayerState(UUID uniqueID) {
         return playerStates.get(uniqueID);
     }
 
@@ -51,7 +51,7 @@ public class StateManager {
      * @param player The {@link Player} to get the state for
      * @return The current state data for the player
      */
-    public PlayerState getOrCreateState(Player player) {
+    public synchronized PlayerState getOrCreateState(Player player) {
         return playerStates.getOrDefault(
             player.getUniqueId(),
             new PlayerState(player.getUniqueId(), player.getName(), false)
@@ -64,7 +64,7 @@ public class StateManager {
      *
      * @param uniqueID The unique ID of the player
      */
-    public void removePlayerState(UUID uniqueID) {
+    public synchronized void removePlayerState(UUID uniqueID) {
         playerStates.remove(uniqueID);
     }
 

--- a/src/main/java/me/ebonjaeger/novuspunishment/action/Action.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/action/Action.java
@@ -36,4 +36,11 @@ public interface Action {
      * @return The reason for the action
      */
     String getReason();
+
+    /**
+     * Get the type of action that the class represents.
+     *
+     * @return The type of action
+     */
+    ActionType getType();
 }

--- a/src/main/java/me/ebonjaeger/novuspunishment/action/ActionType.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/action/ActionType.java
@@ -1,0 +1,37 @@
+/*
+ * Minecraft Dev for IntelliJ
+ *
+ * https://minecraftdev.org
+ *
+ * Copyright (c) 2018 minecraft-dev
+ *
+ * MIT License
+ */
+
+package me.ebonjaeger.novuspunishment.action;
+
+/**
+ * Enum for the different types of {@link Action}s.
+ */
+public enum ActionType {
+
+    MUTE("mute"),
+
+    WARNING("warning"),
+
+    KICK("kick"),
+
+    TEMPORARY_BAN("tempban"),
+
+    PERMANENT_BAN("permban");
+
+    private String name;
+
+    ActionType(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/me/ebonjaeger/novuspunishment/action/ActionType.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/action/ActionType.java
@@ -1,13 +1,3 @@
-/*
- * Minecraft Dev for IntelliJ
- *
- * https://minecraftdev.org
- *
- * Copyright (c) 2018 minecraft-dev
- *
- * MIT License
- */
-
 package me.ebonjaeger.novuspunishment.action;
 
 /**

--- a/src/main/java/me/ebonjaeger/novuspunishment/action/Kick.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/action/Kick.java
@@ -47,4 +47,9 @@ public class Kick implements Action {
     public String getReason() {
         return reason;
     }
+
+    @Override
+    public ActionType getType() {
+        return ActionType.KICK;
+    }
 }

--- a/src/main/java/me/ebonjaeger/novuspunishment/action/Mute.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/action/Mute.java
@@ -58,4 +58,9 @@ public class Mute implements TemporaryAction {
     public String getReason() {
         return reason;
     }
+
+    @Override
+    public ActionType getType() {
+        return ActionType.MUTE;
+    }
 }

--- a/src/main/java/me/ebonjaeger/novuspunishment/action/PermanentBan.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/action/PermanentBan.java
@@ -50,4 +50,9 @@ public class PermanentBan implements Action {
     public String getReason() {
         return reason;
     }
+
+    @Override
+    public ActionType getType() {
+        return ActionType.PERMANENT_BAN;
+    }
 }

--- a/src/main/java/me/ebonjaeger/novuspunishment/action/TemporaryBan.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/action/TemporaryBan.java
@@ -58,4 +58,9 @@ public class TemporaryBan implements TemporaryAction {
     public String getReason() {
         return reason;
     }
+
+    @Override
+    public ActionType getType() {
+        return ActionType.TEMPORARY_BAN;
+    }
 }

--- a/src/main/java/me/ebonjaeger/novuspunishment/action/Warning.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/action/Warning.java
@@ -50,4 +50,9 @@ public class Warning implements Action {
     public String getReason() {
         return reason;
     }
+
+    @Override
+    public ActionType getType() {
+        return ActionType.WARNING;
+    }
 }

--- a/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
@@ -16,6 +16,7 @@ import me.ebonjaeger.novuspunishment.StateManager;
 import me.ebonjaeger.novuspunishment.Utils;
 import me.ebonjaeger.novuspunishment.action.Action;
 import me.ebonjaeger.novuspunishment.datasource.MySQL;
+import org.bukkit.BanList;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -85,7 +86,8 @@ public class GetReportCommand extends BaseCommand {
             }
 
             bukkitService.runTask(() -> {
-                Report report = new Report(target.getName(), finalPage, totalIncidents, incidents, muted);
+                boolean banned = Bukkit.getBanList(BanList.Type.NAME).isBanned(target.getName());
+                Report report = new Report(target.getName(), finalPage, totalIncidents, incidents, banned, muted);
 
                 sendReport(sender, report);
             });
@@ -100,6 +102,7 @@ public class GetReportCommand extends BaseCommand {
         sender.sendMessage(ChatColor.BLUE + "Player: " + ChatColor.WHITE + report.getName());
         sender.sendMessage(ChatColor.BLUE + "Total incidents: " + ChatColor.WHITE + report.getTotalIncidents());
         sender.sendMessage(ChatColor.BLUE + "Currently muted: " + ChatColor.WHITE + report.isMuted());
+        sender.sendMessage(ChatColor.BLUE + "Currently banned: " + ChatColor.WHITE + report.isBanned());
         sender.sendMessage(ChatColor.GRAY + "" + ChatColor.STRIKETHROUGH + " ---------------" + ChatColor.BLUE + " Page " + report.getPage() + "/" + totalPages + ChatColor.GRAY + ChatColor.STRIKETHROUGH + " --------------- ");
 
         // Send incident information
@@ -136,13 +139,15 @@ public class GetReportCommand extends BaseCommand {
         private int page;
         private int totalIncidents;
         private List<Action> incidents;
+        private boolean banned;
         private boolean muted;
 
-        Report(String name, int page, int totalIncidents, List<Action> incidents, boolean muted) {
+        Report(String name, int page, int totalIncidents, List<Action> incidents, boolean banned, boolean muted) {
             this.name = name;
             this.page = page;
             this.totalIncidents = totalIncidents;
             this.incidents = incidents;
+            this.banned = banned;
             this.muted = muted;
         }
 
@@ -160,6 +165,10 @@ public class GetReportCommand extends BaseCommand {
 
         public List<Action> getIncidents() {
             return incidents;
+        }
+
+        public boolean isBanned() {
+            return banned;
         }
 
         public boolean isMuted() {

--- a/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
@@ -1,0 +1,105 @@
+package me.ebonjaeger.novuspunishment.command;
+
+import co.aikar.commands.BaseCommand;
+import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
+import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Optional;
+import java.util.List;
+import java.util.UUID;
+import javax.inject.Inject;
+import me.ebonjaeger.novuspunishment.BukkitService;
+import me.ebonjaeger.novuspunishment.Message;
+import me.ebonjaeger.novuspunishment.Messenger;
+import me.ebonjaeger.novuspunishment.StateManager;
+import me.ebonjaeger.novuspunishment.Utils;
+import me.ebonjaeger.novuspunishment.action.Action;
+import me.ebonjaeger.novuspunishment.datasource.MySQL;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+
+public class GetReportCommand extends BaseCommand {
+
+    private final int PAGE_SIZE = 10;
+
+    private BukkitService bukkitService;
+    private MySQL dataSource;
+    private Messenger messenger;
+    private StateManager stateManager;
+
+    @Inject GetReportCommand(BukkitService bukkitService, MySQL dataSource, Messenger messenger, StateManager stateManager) {
+        this.bukkitService = bukkitService;
+        this.dataSource = dataSource;
+        this.messenger = messenger;
+        this.stateManager = stateManager;
+    }
+
+    @CommandAlias("getreport|gr")
+    @CommandPermission("newpunish.command.getreport")
+    @CommandCompletion("@players")
+    public void onCommand(CommandSender sender, OfflinePlayer target, @Optional Integer page) {
+        if (page == null) {
+            page = 1;
+        }
+
+        int finalPage = page;
+        bukkitService.runTaskAsync(() -> {
+            int totalIncidents = dataSource.getTotalIncidents(target.getUniqueId());
+
+            // Make sure there was no error getting the count
+            if (totalIncidents == -1) {
+                bukkitService.runTask(() -> {
+                    messenger.sendMessage(sender, Message.ERROR_GETTING_COUNT);
+                });
+
+                return;
+            }
+
+            int totalPages = (totalIncidents + PAGE_SIZE - 1) * PAGE_SIZE;
+
+            // Check page bounds
+            if (finalPage < 1 || finalPage > totalPages) {
+                bukkitService.runTask(() -> {
+                    messenger.sendMessage(sender, Message.INVALID_PAGE);
+                });
+
+                return;
+            }
+
+            List<Action> incidents = dataSource.getActionsAgainstUser(target.getUniqueId(), finalPage, PAGE_SIZE);
+
+            bukkitService.runTask(() -> sendReport(sender, target.getName(), finalPage, totalIncidents, incidents));
+        });
+    }
+
+    private void sendReport(CommandSender sender, String name, int page, int totalIncidents, List<Action> incidents) {
+        int totalPages = (totalIncidents + PAGE_SIZE - 1) * PAGE_SIZE;
+
+        // Send header and counts
+        sender.sendMessage(ChatColor.GRAY + "" + ChatColor.STRIKETHROUGH + " ---------------------------------------------------- ");
+        sender.sendMessage(ChatColor.BLUE + "Player: " + ChatColor.WHITE + name);
+        sender.sendMessage(ChatColor.BLUE + "Total incidents: " + ChatColor.WHITE + totalIncidents);
+        sender.sendMessage(ChatColor.GRAY + "" + ChatColor.STRIKETHROUGH + " ---------------" + ChatColor.BLUE + " Page " + page + "/" + totalPages + ChatColor.GRAY + ChatColor.STRIKETHROUGH + " --------------- ");
+
+        // Send incident information
+        for (Action incident : incidents) {
+            String timeStamp = Utils.formatTime(incident.getTimestamp());
+
+            String staffName;
+            if (incident.getStaff().equals(Bukkit.getConsoleSender().getName())) {
+                staffName = "console";
+            } else {
+                staffName = Bukkit.getOfflinePlayer(UUID.fromString(incident.getStaff())).getName();
+            }
+
+            sender.sendMessage(String.format(ChatColor.GRAY + " - " + ChatColor.WHITE + "%s " + ChatColor.GRAY + "on " + ChatColor.WHITE + "%s " +
+                    ChatColor.GRAY + "by " + ChatColor.WHITE + "%s " + ChatColor.GRAY + "for: " + ChatColor.WHITE + "%s",
+                incident.getType().getName(), timeStamp, staffName, incident.getReason()
+            ));
+        }
+
+        sender.sendMessage(ChatColor.GRAY + "" + ChatColor.STRIKETHROUGH + " ---------------------------------------------------- ");
+    }
+}

--- a/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
@@ -52,9 +52,7 @@ public class GetReportCommand extends BaseCommand {
 
             // Make sure there was no error getting the count
             if (totalIncidents == -1) {
-                bukkitService.runTask(() -> {
-                    messenger.sendMessage(sender, Message.ERROR_GETTING_COUNT);
-                });
+                bukkitService.runTask(() -> messenger.sendMessage(sender, Message.ERROR_GETTING_COUNT));
 
                 return;
             }
@@ -63,9 +61,7 @@ public class GetReportCommand extends BaseCommand {
 
             // Check page bounds
             if (finalPage < 1 || finalPage > totalPages) {
-                bukkitService.runTask(() -> {
-                    messenger.sendMessage(sender, Message.INVALID_PAGE);
-                });
+                bukkitService.runTask(() -> messenger.sendMessage(sender, Message.INVALID_PAGE));
 
                 return;
             }

--- a/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
@@ -113,9 +113,14 @@ public class GetReportCommand extends BaseCommand {
                 staffName = Bukkit.getOfflinePlayer(UUID.fromString(incident.getStaff())).getName();
             }
 
+            String reason = "";
+            if (incident.getReason() != null) {
+                reason = incident.getReason();
+            }
+
             sender.sendMessage(String.format(ChatColor.GRAY + " - " + ChatColor.WHITE + "%s " + ChatColor.GRAY + "on " + ChatColor.WHITE + "%s " +
                     ChatColor.GRAY + "by " + ChatColor.WHITE + "%s " + ChatColor.GRAY + "for: " + ChatColor.WHITE + "%s",
-                incident.getType().getName(), timeStamp, staffName, incident.getReason()
+                incident.getType().getName(), timeStamp, staffName, reason
             ));
         }
 

--- a/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
@@ -4,7 +4,7 @@ import co.aikar.commands.BaseCommand;
 import co.aikar.commands.annotation.CommandAlias;
 import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
-import co.aikar.commands.annotation.Optional;
+import co.aikar.commands.annotation.Default;
 import java.util.List;
 import java.util.UUID;
 import javax.inject.Inject;
@@ -41,12 +41,7 @@ public class GetReportCommand extends BaseCommand {
     @CommandAlias("getreport|gr")
     @CommandPermission("newpunish.command.getreport")
     @CommandCompletion("@players")
-    public void onCommand(CommandSender sender, OfflinePlayer target, @Optional Integer page) {
-        if (page == null) {
-            page = 1;
-        }
-
-        int finalPage = page;
+    public void onCommand(CommandSender sender, OfflinePlayer target, @Default("1") Integer page) {
         bukkitService.runTaskAsync(() -> {
             int totalIncidents = dataSource.getTotalIncidents(target.getUniqueId());
 
@@ -60,13 +55,13 @@ public class GetReportCommand extends BaseCommand {
             int totalPages = (totalIncidents + PAGE_SIZE - 1) * PAGE_SIZE;
 
             // Check page bounds
-            if (finalPage < 1 || finalPage > totalPages) {
+            if (page < 1 || page > totalPages) {
                 bukkitService.runTask(() -> messenger.sendMessage(sender, Message.INVALID_PAGE));
 
                 return;
             }
 
-            List<Action> incidents = dataSource.getActionsAgainstUser(target.getUniqueId(), finalPage, PAGE_SIZE);
+            List<Action> incidents = dataSource.getActionsAgainstUser(target.getUniqueId(), page, PAGE_SIZE);
 
             // Get player state for muted status
             PlayerState state = stateManager.getPlayerState(target.getUniqueId());
@@ -83,7 +78,7 @@ public class GetReportCommand extends BaseCommand {
 
             bukkitService.runTask(() -> {
                 boolean banned = Bukkit.getBanList(BanList.Type.NAME).isBanned(target.getName());
-                Report report = new Report(target.getName(), finalPage, totalIncidents, incidents, banned, muted);
+                Report report = new Report(target.getName(), page, totalIncidents, incidents, banned, muted);
 
                 sendReport(sender, report);
             });

--- a/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/command/GetReportCommand.java
@@ -52,7 +52,7 @@ public class GetReportCommand extends BaseCommand {
                 return;
             }
 
-            int totalPages = (totalIncidents + PAGE_SIZE - 1) * PAGE_SIZE;
+            int totalPages = (totalIncidents + PAGE_SIZE - 1) / PAGE_SIZE;
 
             // Check page bounds
             if (page < 1 || page > totalPages) {
@@ -86,7 +86,7 @@ public class GetReportCommand extends BaseCommand {
     }
 
     private void sendReport(CommandSender sender, Report report) {
-        int totalPages = (report.getTotalIncidents() + PAGE_SIZE - 1) * PAGE_SIZE;
+        int totalPages = (report.getTotalIncidents() + PAGE_SIZE - 1) / PAGE_SIZE;
 
         // Send header and counts
         sender.sendMessage(ChatColor.GRAY + "" + ChatColor.STRIKETHROUGH + " ---------------------------------------------------- ");

--- a/src/main/java/me/ebonjaeger/novuspunishment/datasource/MySQL.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/datasource/MySQL.java
@@ -279,6 +279,38 @@ public class MySQL {
      */
 
     /**
+     * Get the total number of past incidents for a player.
+     * <p>
+     * If there was an error getting the number, <code>-1</code> will be returned.
+     *
+     * @param playerUUID The player to look up
+     * @return The number of incidents
+     */
+    public int getTotalIncidents(UUID playerUUID) {
+        int incidents = 0;
+
+        try (
+            Connection conn = getConnection();
+            PreparedStatement statement = conn.prepareStatement(MySqlStatements.getTotalIncidents(prefix))
+        ) {
+            statement.setString(1, playerUUID.toString());
+
+            ResultSet result = statement.executeQuery();
+
+            if (result.next()) {
+                incidents = result.getInt("_count");
+            }
+
+            result.close();
+        } catch (SQLException ex) {
+            ConsoleLogger.severe("Unable to get total incident count for '" + playerUUID.toString() + "':", ex);
+            incidents = -1;
+        }
+
+        return incidents;
+    }
+
+    /**
      * Get a page view of a player's past incidents.
      * <p>
      * What is returned will be limited to only the results in the requested page.

--- a/src/main/java/me/ebonjaeger/novuspunishment/datasource/MySqlStatements.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/datasource/MySqlStatements.java
@@ -70,6 +70,12 @@ class MySqlStatements {
             "LIMIT " + pageSize + " OFFSET " + offset + ";";
     }
 
+    static String getTotalIncidents(String prefix) {
+        return "SELECT COUNT(*) AS _count" +
+            "FROM " + prefix + "player_actions " +
+            "WHERE " + Columns.UUID + "=?;";
+    }
+
     static String getPlayerStmt(String prefix) {
         return "SELECT " + Columns.PLAYERNAME + ", " + Columns.MUTED + ", " + Columns.EXPIRES + " " +
             "FROM " + prefix + "player_state " +

--- a/src/main/java/me/ebonjaeger/novuspunishment/datasource/MySqlStatements.java
+++ b/src/main/java/me/ebonjaeger/novuspunishment/datasource/MySqlStatements.java
@@ -71,7 +71,7 @@ class MySqlStatements {
     }
 
     static String getTotalIncidents(String prefix) {
-        return "SELECT COUNT(*) AS _count" +
+        return "SELECT COUNT(*) AS _count " +
             "FROM " + prefix + "player_actions " +
             "WHERE " + Columns.UUID + "=?;";
     }


### PR DESCRIPTION
Implement the command `/getreport <name> [page]` to allow staff members to view the past incidents of players.

The methods for viewing and mutating the player state cache were made synchronized for easier access while not on the main thread, while still trying to remain performant (inspiration taken from Aikar's work on the new `ChunkMap` for Paper).